### PR TITLE
Comments Resolution

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -418,7 +418,14 @@ csharp_style_prefer_top_level_statements = true:silent
 csharp_style_prefer_primary_constructors = true:suggestion
 
 # CA2016: Forward the CancellationToken parameter to methods that take one
-dotnet_diagnostic.CA2016.severity = error
+dotnet_diagnostic.CA2016.severity = warning
+
+# IDE0005: Remove unnecessary using directives
+dotnet_diagnostic.IDE0005.severity = warning
+
+# Suppresion of documentation generation warnings
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
 
 ## Analyzers by file
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,6 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/TeaPie.DotnetTool/Program.cs
+++ b/src/TeaPie.DotnetTool/Program.cs
@@ -10,7 +10,7 @@ var services = new ServiceCollection();
 services.ConfigureServices();
 services.ConfigureLogging();
 services.ConfigureAccessors();
-services.ConfigureSteps();
+services.AddSteps();
 services.AddSingleton<IPipeline, ApplicationPipeline>();
 
 var provider = services.BuildServiceProvider();

--- a/src/TeaPie/Extensions/ServiceCollectionExtensions.cs
+++ b/src/TeaPie/Extensions/ServiceCollectionExtensions.cs
@@ -34,7 +34,7 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection ConfigureSteps(this IServiceCollection services)
+    public static IServiceCollection AddSteps(this IServiceCollection services)
     {
         var assembly = Assembly.GetExecutingAssembly();
 

--- a/src/TeaPie/Pipelines/Application/ApplicationContext.cs
+++ b/src/TeaPie/Pipelines/Application/ApplicationContext.cs
@@ -10,7 +10,7 @@ internal class ApplicationContext(
     IServiceProvider serviceProvider,
     string tempFolder = "")
 {
-    public string Path { get; set; } = path;
+    public string Path { get; } = path;
     public string TempFolderPath { get; set; } = tempFolder;
 
     public IReadOnlyDictionary<string, TestCase> TestCases { get; set; } = new Dictionary<string, TestCase>();
@@ -18,5 +18,5 @@ internal class ApplicationContext(
 
     public ILogger Logger { get; set; } = logger;
 
-    public IServiceProvider ServiceProvider { get; set; } = serviceProvider;
+    public IServiceProvider ServiceProvider { get; } = serviceProvider;
 }

--- a/src/TeaPie/Pipelines/Scripts/ExecuteScriptStep.cs
+++ b/src/TeaPie/Pipelines/Scripts/ExecuteScriptStep.cs
@@ -25,8 +25,7 @@ internal class ExecuteScriptStep(IScriptExecutionContextAccessor scriptExecution
 
             await script.RunAsync(
                 globals: new Globals() { tp = TeaPie.Instance },
-                cancellationToken: cancellationToken
-            );
+                cancellationToken: cancellationToken);
 
             context.Logger.LogTrace("Execution of the {ScriptType} on path '{RelativePath}' finished.",
                 GetTypeOfScript(scriptExecutionContext),
@@ -43,25 +42,17 @@ internal class ExecuteScriptStep(IScriptExecutionContextAccessor scriptExecution
 
     private static string GetTypeOfScript(ScriptExecutionContext scriptExecutionContext)
     {
-        var path = scriptExecutionContext.Script.File.Path;
-        if (!string.IsNullOrEmpty(path))
-        {
-            if (path.EndsWith($"{Constants.PreRequestSuffix}{Constants.ScriptFileExtension}"))
-            {
-                return "Pre-Request script";
-            }
-            else if (path.EndsWith($"{Constants.PostResponseSuffix}{Constants.ScriptFileExtension}"))
-            {
-                return "Post-Response script";
-            }
-            else
-            {
-                return "User-defined script";
-            }
-        }
-        else
+        if (string.IsNullOrEmpty(scriptExecutionContext.Script.File.Path))
         {
             return "Unknown script";
         }
+
+        var path = scriptExecutionContext.Script.File.Path;
+        return path switch
+        {
+            var p when p.EndsWith($"{Constants.PreRequestSuffix}{Constants.ScriptFileExtension}") => "Pre-Request script",
+            var p when p.EndsWith($"{Constants.PostResponseSuffix}{Constants.ScriptFileExtension}") => "Post-Response script",
+            _ => "User-defined script"
+        };
     }
 }

--- a/src/TeaPie/ScriptHandling/ScriptExecutionContext.cs
+++ b/src/TeaPie/ScriptHandling/ScriptExecutionContext.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Scripting;
+﻿using Microsoft.CodeAnalysis.Scripting;
 using System.Diagnostics;
 using Script = TeaPie.StructureExploration.IO.Script;
 

--- a/src/TeaPie/StructureExploration/StructureExplorer.cs
+++ b/src/TeaPie/StructureExploration/StructureExplorer.cs
@@ -37,12 +37,12 @@ internal partial class StructureExplorer(ILogger<StructureExplorer> logger) : IS
     }
 
     /// <summary>
-    /// Recursive Depth-first algorithm, which examines file system tree. Traversal path is saved in <param cref="testCases">
+    /// Recursive Depth-first algorithm, which examines file system tree. Traversal path is saved in <paramref name="testCases"/>
     /// parameter in form of test cases. Each folder can have sub-folders and/or test cases. Test case is represented by '.http'
     /// file and possibly by other (e.g. script files with '.csx' extension) files.
     /// </summary>
-    /// <param name="currentFolder">Folder that should be examined.</param>
-    /// <param name="testCases">Depth-first order of test cases.</param>
+    /// <param name="currentFolder">Folder to be explored.</param>
+    /// <param name="testCases">List of explored test cases.</param>
     private static void ExploreFolder(Folder currentFolder, Dictionary<string, TestCase> testCases)
     {
         var subFolderPaths = Directory.GetDirectories(currentFolder.Path)

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,6 +6,8 @@
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/tests/TeaPie.Tests/Pipelines/Scripts/ExecuteScriptStepShould.cs
+++ b/tests/TeaPie.Tests/Pipelines/Scripts/ExecuteScriptStepShould.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using TeaPie.Pipelines.Application;
 using TeaPie.Pipelines.Scripts;
@@ -10,16 +11,21 @@ public class ExecuteScriptStepShould
     [Fact]
     public async void ScriptShouldAccessTeaPieInstanceWithoutAnyProblem()
     {
-        var logger = NullLogger.Instance;
+        var logger = Substitute.For<ILogger>();
         var context = ScriptHelper.GetScriptExecutionContext(ScriptIndex.ScriptAccessingTeaPieInstance);
         var accessor = new ScriptExecutionContextAccessor() { ScriptExecutionContext = context };
         TeaPie.Create(logger);
         await ScriptHelper.PrepareScriptForExecution(context);
 
         var step = new ExecuteScriptStep(accessor);
-        var appContext = new ApplicationContext(string.Empty, logger, Substitute.For<IServiceProvider>());
+        var appContext = new ApplicationContext(
+            string.Empty,
+            Substitute.For<ILogger<ApplicationContext>>(),
+            Substitute.For<IServiceProvider>());
 
         await step.Execute(appContext);
+
+        logger.Received(1).LogInformation("It is possible to access TeaPie instance!");
     }
 
     [Fact]


### PR DESCRIPTION
Comments from PRs #21, #20 and #19 are resolved here, namely:
- Addition of **warning** for unused `using`s during the build process (`.editorconfig`), removal of redundant `using`s
- Rename from `ConfigureSteps` to `AddSteps`
- **Removal of some setters** within `ApplicationContext`
- **Readability simplification** of `GetTypeOfScript` method
- **Fix of wrongly written documentation comment**
- Enforcing **check of actual execution of the script** within `ExecuteScriptStepShould` test case