### PR TITLE
Bugfix - Empty Path Error

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>1.1.2</Version>
+        <Version>1.1.3</Version>
         <Authors>Matej Grochal</Authors>
         <Company>KROS a.s.</Company>
         <Copyright>Copyright © KROS a.s.</Copyright>

--- a/src/TeaPie.DotnetTool/CompileScriptCommand.cs
+++ b/src/TeaPie.DotnetTool/CompileScriptCommand.cs
@@ -12,7 +12,7 @@ internal class CompileScriptCommand : ApplicationCommandBase<CompileScriptComman
     {
         var pathToLogFile = settings.LogFile ?? string.Empty;
         var logLevel = Helper.ResolveLogLevel(settings);
-        var path = PathResolver.Resolve(settings.Path, string.Empty);
+        var path = PathResolver.Resolve(settings.Path, Directory.GetCurrentDirectory());
 
         var appBuilder = ApplicationBuilder.Create(path.IsCollectionPath());
 

--- a/src/TeaPie.DotnetTool/ExploreCommand.cs
+++ b/src/TeaPie.DotnetTool/ExploreCommand.cs
@@ -10,7 +10,7 @@ internal class ExploreCommand : ApplicationCommandBase<ExploreCommand.Settings>
     {
         var pathToLogFile = settings.LogFile ?? string.Empty;
         var logLevel = Helper.ResolveLogLevel(settings);
-        var path = PathResolver.Resolve(settings.Path, string.Empty);
+        var path = PathResolver.Resolve(settings.Path, Directory.GetCurrentDirectory());
 
         var appBuilder = ApplicationBuilder.Create(path.IsCollectionPath());
 

--- a/src/TeaPie.DotnetTool/TestCommand.cs
+++ b/src/TeaPie.DotnetTool/TestCommand.cs
@@ -10,7 +10,7 @@ internal sealed class TestCommand : ApplicationCommandBase<TestCommand.Settings>
     {
         var pathToLogFile = settings.LogFile ?? string.Empty;
         var logLevel = Helper.ResolveLogLevel(settings);
-        var path = PathResolver.Resolve(settings.Path, string.Empty);
+        var path = PathResolver.Resolve(settings.Path, Directory.GetCurrentDirectory());
 
         var appBuilder = ApplicationBuilder.Create(path.IsCollectionPath());
 


### PR DESCRIPTION
A previous refactoring of the method that checks **whether the path is a collection or test case path** introduced an **error**. The extension method `IsCollectionPath()` is verifying if a folder or file exist, but since an empty string was passed by default, it threw an exception stating that the **path `''` does not exist**. As a result, **it was impossible to run the command in the current directory** (without explicitly passing the path). This has now been **fixed by properly passing the current directory as the path** (instead of an empty string).

Because this **fix is critical**, a **version bump** to `1.1.3` is **required.**