### PR TITLE
Optimizations + Asynchronous Reporting

### DIFF
--- a/demo/.teapie/init.csx
+++ b/demo/.teapie/init.csx
@@ -71,7 +71,7 @@ tp.RegisterRetryStrategy("Custom retry", new() { MaxRetryAttempts = 2 });
 
 // At the end of the collection run, a test results report is generated.
 // Users can add a custom reporting method that will be triggered automatically.
-tp.RegisterReporter(summary =>
+tp.RegisterReporter(async summary =>
 {
     Console.Write("Custom reporter report: ");
 
@@ -88,6 +88,7 @@ tp.RegisterReporter(summary =>
     }
 
     Console.ResetColor();
+    await Task.CompletedTask;
 });
 
 // For more advanced and customized reporting, use:

--- a/src/TeaPie/ApplicationBuilder.cs
+++ b/src/TeaPie/ApplicationBuilder.cs
@@ -166,7 +166,8 @@ public sealed class ApplicationBuilder
             provider.GetRequiredService<IRetryStrategyRegistry>(),
             provider.GetRequiredService<IAuthProviderRegistry>(),
             provider.GetRequiredService<IAuthProviderAccessor>(),
-            provider.GetRequiredService<ITestFactory>());
+            provider.GetRequiredService<ITestFactory>(),
+            provider.GetRequiredService<IHttpClientFactory>());
 
     private ApplicationPipeline BuildPipeline(IServiceProvider provider)
         => !string.IsNullOrEmpty(_scriptPath)

--- a/src/TeaPie/Http/DisposeRequestStep.cs
+++ b/src/TeaPie/Http/DisposeRequestStep.cs
@@ -1,0 +1,21 @@
+﻿using TeaPie.Pipelines;
+
+namespace TeaPie.Http;
+
+internal class DisposeRequestStep(IRequestExecutionContextAccessor contextAccessor) : IPipelineStep
+{
+    private readonly IRequestExecutionContextAccessor _requestExecutionContextAccessor = contextAccessor;
+
+    public async Task Execute(ApplicationContext context, CancellationToken cancellationToken = default)
+    {
+        ValidateContext(out var requestExecutionContext);
+        requestExecutionContext.Dispose();
+        await Task.CompletedTask;
+    }
+
+    private void ValidateContext(out RequestExecutionContext requestExecutionContext)
+    {
+        const string activityName = "dispose HTTP request";
+        ExecutionContextValidator.Validate(_requestExecutionContextAccessor, out requestExecutionContext, activityName);
+    }
+}

--- a/src/TeaPie/Http/RequestExecutionContext.cs
+++ b/src/TeaPie/Http/RequestExecutionContext.cs
@@ -7,7 +7,7 @@ using TeaPie.TestCases;
 namespace TeaPie.Http;
 
 [DebuggerDisplay("{RequestFile}")]
-internal class RequestExecutionContext(InternalFile requestFile, TestCaseExecutionContext? testCaseExecutionContext = null)
+internal class RequestExecutionContext(InternalFile requestFile, TestCaseExecutionContext? testCaseExecutionContext = null) : IDisposable
 {
     public TestCaseExecutionContext? TestCaseExecutionContext { get; set; } = testCaseExecutionContext;
     public InternalFile RequestFile { get; set; } = requestFile;
@@ -17,4 +17,9 @@ internal class RequestExecutionContext(InternalFile requestFile, TestCaseExecuti
     public HttpResponseMessage? Response { get; set; }
     public ResiliencePipeline<HttpResponseMessage>? ResiliencePipeline { get; set; }
     public IAuthProvider? AuthProvider { get; set; }
+
+    public void Dispose()
+    {
+        RawContent = null;
+    }
 }

--- a/src/TeaPie/Http/RequestStepsFactory.cs
+++ b/src/TeaPie/Http/RequestStepsFactory.cs
@@ -20,5 +20,6 @@ internal static class RequestStepsFactory
 
     private static IPipelineStep[] CreateSteps(IServiceProvider provider)
         => [provider.GetStep<ParseHttpRequestStep>(),
-            provider.GetStep<ExecuteRequestStep>()];
+            provider.GetStep<ExecuteRequestStep>(),
+            provider.GetStep<DisposeRequestStep>()];
 }

--- a/src/TeaPie/Reporting/IReporter.cs
+++ b/src/TeaPie/Reporting/IReporter.cs
@@ -2,10 +2,10 @@
 
 public interface IReporter
 {
-    void Report();
+    Task Report();
 }
 
 public interface IReporter<TReportedObject>
 {
-    void Report(TReportedObject report);
+    Task Report(TReportedObject report);
 }

--- a/src/TeaPie/Reporting/InlineTestResultsSummaryReporter.cs
+++ b/src/TeaPie/Reporting/InlineTestResultsSummaryReporter.cs
@@ -2,9 +2,9 @@
 
 namespace TeaPie.Reporting;
 
-internal class InlineTestResultsSummaryReporter(Action<TestResultsSummary> reportAction) : IReporter<TestResultsSummary>
+internal class InlineTestResultsSummaryReporter(Func<TestResultsSummary, Task> reportAction) : IReporter<TestResultsSummary>
 {
-    private readonly Action<TestResultsSummary> _reportAction = reportAction;
+    private readonly Func<TestResultsSummary, Task> _reportAction = reportAction;
 
-    public void Report(TestResultsSummary report) => _reportAction(report);
+    public Task Report(TestResultsSummary report) => _reportAction(report);
 }

--- a/src/TeaPie/Reporting/JUnitXmlTestResultsSummaryReporter.cs
+++ b/src/TeaPie/Reporting/JUnitXmlTestResultsSummaryReporter.cs
@@ -7,7 +7,7 @@ internal class JUnitXmlTestResultsSummaryReporter(string reportFilePath) : IRepo
 {
     private readonly string _reportFilePath = reportFilePath;
 
-    public void Report(TestResultsSummary report)
+    public async Task Report(TestResultsSummary report)
     {
         using var writer = new JUnitXmlWriter(_reportFilePath);
 
@@ -15,6 +15,8 @@ internal class JUnitXmlTestResultsSummaryReporter(string reportFilePath) : IRepo
         {
             WriteCollectionReport(writer, collectionSummary);
         }
+
+        await Task.CompletedTask;
     }
 
     private static void WriteCollectionReport(

--- a/src/TeaPie/Reporting/ReportTestResultsSummaryStep.cs
+++ b/src/TeaPie/Reporting/ReportTestResultsSummaryStep.cs
@@ -7,9 +7,7 @@ internal class ReportTestResultsSummaryStep : IPipelineStep
     public async Task Execute(ApplicationContext context, CancellationToken cancellationToken = default)
     {
         RegisterReporters(context.ReportFilePath, context.Reporter);
-        context.Reporter.Report();
-
-        await Task.CompletedTask;
+        await context.Reporter.Report();
     }
 
     public bool ShouldExecute(ApplicationContext context) => true;

--- a/src/TeaPie/Reporting/SpectreConsoleTestResultsSummaryReporter.cs
+++ b/src/TeaPie/Reporting/SpectreConsoleTestResultsSummaryReporter.cs
@@ -6,7 +6,7 @@ namespace TeaPie.Reporting;
 
 internal class SpectreConsoleTestResultsSummaryReporter : IReporter<TestResultsSummary>
 {
-    public void Report(TestResultsSummary report)
+    public async Task Report(TestResultsSummary report)
     {
         if (report.NumberOfTests > 0)
         {
@@ -16,6 +16,8 @@ internal class SpectreConsoleTestResultsSummaryReporter : IReporter<TestResultsS
         {
             ReportZeroTests();
         }
+
+        await Task.CompletedTask;
     }
 
     private static void ReportTestResultsSummary(TestResultsSummary summary)

--- a/src/TeaPie/Reporting/TeaPieReportingExtensions.cs
+++ b/src/TeaPie/Reporting/TeaPieReportingExtensions.cs
@@ -23,7 +23,7 @@ public static class TeaPieReportingExtensions
     /// </summary>
     /// <param name="teaPie">The current context instance.</param>
     /// <param name="onReportAction">The action to be executed for test results summary report.</param>
-    public static void RegisterReporter(this TeaPie teaPie, Action<TestResultsSummary> onReportAction)
+    public static void RegisterReporter(this TeaPie teaPie, Func<TestResultsSummary, Task> onReportAction)
     {
         teaPie._reporter.RegisterReporter(new InlineTestResultsSummaryReporter(onReportAction));
         teaPie.Logger.LogInformation("Custom reporter was successfully registered.");

--- a/src/TeaPie/Reporting/TestResultsSummaryReporter.cs
+++ b/src/TeaPie/Reporting/TestResultsSummaryReporter.cs
@@ -32,11 +32,11 @@ internal class TestResultsSummaryReporter(ITestResultsSummaryAccessor accessor) 
         }
     }
 
-    public void Report()
+    public async Task Report()
     {
         foreach (var reporter in _reporters)
         {
-            reporter.Report(_summary);
+            await reporter.Report(_summary);
         }
     }
 

--- a/src/TeaPie/Scripts/DisposeScriptStep.cs
+++ b/src/TeaPie/Scripts/DisposeScriptStep.cs
@@ -1,0 +1,21 @@
+﻿using TeaPie.Pipelines;
+
+namespace TeaPie.Scripts;
+
+internal class DisposeScriptStep(IScriptExecutionContextAccessor scriptExecutionContextAccessor) : IPipelineStep
+{
+    private readonly IScriptExecutionContextAccessor _scriptContextAccessor = scriptExecutionContextAccessor;
+
+    public async Task Execute(ApplicationContext context, CancellationToken cancellationToken = default)
+    {
+        ValidateContext(out var scriptExecutionContext);
+        scriptExecutionContext.Dispose();
+        await Task.CompletedTask;
+    }
+
+    private void ValidateContext(out ScriptExecutionContext scriptExecutionContext)
+    {
+        const string activityName = "dispose script";
+        ExecutionContextValidator.Validate(_scriptContextAccessor, out scriptExecutionContext, activityName);
+    }
+}

--- a/src/TeaPie/Scripts/ScriptExecutionContext.cs
+++ b/src/TeaPie/Scripts/ScriptExecutionContext.cs
@@ -5,10 +5,17 @@ using Script = TeaPie.StructureExploration.Script;
 namespace TeaPie.Scripts;
 
 [DebuggerDisplay("{Script}")]
-internal class ScriptExecutionContext(Script script)
+internal class ScriptExecutionContext(Script script) : IDisposable
 {
     public Script Script { get; set; } = script;
     public string? RawContent { get; set; }
     public string? ProcessedContent { get; set; }
     public Script<object>? ScriptObject { get; set; }
+
+    public void Dispose()
+    {
+        RawContent = null;
+        ProcessedContent = null;
+        ScriptObject = null;
+    }
 }

--- a/src/TeaPie/Scripts/ScriptStepsFactory.cs
+++ b/src/TeaPie/Scripts/ScriptStepsFactory.cs
@@ -32,12 +32,14 @@ internal static class ScriptStepsFactory
     private static IPipelineStep[] GetStepsForScriptPreProcess(IServiceProvider provider)
         => [provider.GetStep<ReadScriptFileStep>(),
             provider.GetStep<PreProcessScriptStep>(),
-            provider.GetStep<SaveTempScriptStep>()];
+            provider.GetStep<SaveTempScriptStep>(),
+            provider.GetStep<DisposeScriptStep>()];
 
     private static IPipelineStep[] GetStepsForScriptPreProcessAndExecution(IServiceProvider provider)
         => [provider.GetStep<ReadScriptFileStep>(),
             provider.GetStep<PreProcessScriptStep>(),
             provider.GetStep<SaveTempScriptStep>(),
             provider.GetStep<CompileScriptStep>(),
-            provider.GetStep<ExecuteScriptStep>()];
+            provider.GetStep<ExecuteScriptStep>(),
+            provider.GetStep<DisposeScriptStep>()];
 }

--- a/src/TeaPie/TeaPie.cs
+++ b/src/TeaPie/TeaPie.cs
@@ -24,7 +24,8 @@ public sealed class TeaPie : IVariablesExposer, IExecutionContextExposer
         IRetryStrategyRegistry retryStrategiesRegistry,
         IAuthProviderRegistry authenticationProviderRegistry,
         IAuthProviderAccessor defaultAuthProviderAccessor,
-        ITestFactory predefinedTestFactory)
+        ITestFactory predefinedTestFactory,
+        IHttpClientFactory httpClientFactory)
     {
         Instance = new(
             applicationContext,
@@ -37,7 +38,8 @@ public sealed class TeaPie : IVariablesExposer, IExecutionContextExposer
             retryStrategiesRegistry,
             authenticationProviderRegistry,
             defaultAuthProviderAccessor,
-            predefinedTestFactory);
+            predefinedTestFactory,
+            httpClientFactory);
 
         return Instance;
     }
@@ -53,7 +55,8 @@ public sealed class TeaPie : IVariablesExposer, IExecutionContextExposer
         IRetryStrategyRegistry retryStrategiesRegistry,
         IAuthProviderRegistry authenticationProviderRegistry,
         IAuthProviderAccessor authProviderAccessor,
-        ITestFactory predefinedTestFactory)
+        ITestFactory predefinedTestFactory,
+        IHttpClientFactory httpClientFactory)
     {
         _applicationContext = applicationContext;
         _serviceProvider = serviceProvider;
@@ -67,6 +70,7 @@ public sealed class TeaPie : IVariablesExposer, IExecutionContextExposer
         _authenticationProviderRegistry = authenticationProviderRegistry;
         _authProviderAccessor = authProviderAccessor;
         _testFactory = predefinedTestFactory;
+        _httpClientFactory = httpClientFactory;
     }
 
     internal IServiceProvider _serviceProvider;
@@ -171,7 +175,17 @@ public sealed class TeaPie : IVariablesExposer, IExecutionContextExposer
     internal readonly IAuthProviderAccessor _authProviderAccessor;
     #endregion
 
-    #region Exit
+    #region HTTP
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public HttpClient GetHttpClient(string? name = null)
+        => name is null
+            ? _httpClientFactory.CreateClient()
+            : _httpClientFactory.CreateClient(name);
+
+    #endregion
+
+    #region Premature Termination
     public void Exit(int exitCode = 0, string? reason = null)
         => _applicationContext.PrematureTermination =
             new("User", TerminationType.UserAction, reason ?? $"Terminated at: {DateTime.Now}", exitCode);

--- a/tests/TeaPie.Tests/Reporting/DummyReporter.cs
+++ b/tests/TeaPie.Tests/Reporting/DummyReporter.cs
@@ -7,5 +7,9 @@ public class DummyReporter : IReporter<TestResultsSummary>
 {
     public bool Reported { get; private set; }
 
-    public void Report(TestResultsSummary report) => Reported = true;
+    public async Task Report(TestResultsSummary report)
+    {
+        Reported = true;
+        await Task.CompletedTask;
+    }
 }

--- a/tests/TeaPie.Tests/Reporting/TeaPieReportingExtensionsShould.cs
+++ b/tests/TeaPie.Tests/Reporting/TeaPieReportingExtensionsShould.cs
@@ -8,7 +8,7 @@ namespace TeaPie.Tests.Reporting;
 public class TeaPieReportingExtensionsShould
 {
     [Fact]
-    public void RegisterReporterCorrectly()
+    public async Task RegisterReporterCorrectly()
     {
         var accessor = new TestResultsSummaryAccessor() { Summary = new() };
         var reporter = new TestResultsSummaryReporter(accessor);
@@ -17,22 +17,26 @@ public class TeaPieReportingExtensionsShould
 
         teaPie.RegisterReporter(dummyReporter);
 
-        reporter.Report();
+        await reporter.Report();
 
         True(dummyReporter.Reported);
     }
 
     [Fact]
-    public void RegisterInlineReporterCorrectly()
+    public async Task RegisterInlineReporterCorrectly()
     {
         var accessor = new TestResultsSummaryAccessor() { Summary = new() };
         var reporter = new TestResultsSummaryReporter(accessor);
         var teaPie = PrepareTeaPieInstance(reporter);
         var reported = false;
 
-        teaPie.RegisterReporter(_ => reported = true);
+        teaPie.RegisterReporter(async _ =>
+        {
+            reported = true;
+            await Task.CompletedTask;
+        });
 
-        reporter.Report();
+        await reporter.Report();
 
         True(reported);
     }

--- a/tests/TeaPie.Tests/TeaPieBuilder.cs
+++ b/tests/TeaPie.Tests/TeaPieBuilder.cs
@@ -31,6 +31,7 @@ internal class TeaPieBuilder
         _serviceCollection.AddSingleton(Substitute.For<IAuthProviderAccessor>());
         _serviceCollection.AddSingleton(Substitute.For<IRetryStrategyRegistry>());
         _serviceCollection.AddSingleton(Substitute.For<ITestFactory>());
+        _serviceCollection.AddSingleton(Substitute.For<IHttpClientFactory>());
     }
 
     public TeaPieBuilder WithService<TService>(TService implementation) where TService : class
@@ -58,7 +59,8 @@ internal class TeaPieBuilder
             provider.GetRequiredService<IRetryStrategyRegistry>(),
             provider.GetRequiredService<IAuthProviderRegistry>(),
             provider.GetRequiredService<IAuthProviderAccessor>(),
-            provider.GetRequiredService<ITestFactory>());
+            provider.GetRequiredService<ITestFactory>(),
+            provider.GetRequiredService<IHttpClientFactory>());
     }
 
     public TeaPieBuilder WithApplicationContext(ApplicationContext appContext)


### PR DESCRIPTION
This PR focuses on optimizations:
- **Memory usage was too excessive**, in the collection with **101 test cases** it took around **1.6 GiB** of space in RAM. It was resolved by **disposing already unnecessary objects**, especially **compiled scripts objects** as well as its string **contents.** **After** this **optimization**, the application **consumes around 200 MB** on the same collection.
- `HttpClient` **for end-user wasn't supported in any way**, which implied usage of `new HttpClient()` within `.csx` scripts. This is **not recommended at all**, since it can lead to `SocketExhaustionException`. Now, there is new method within `TeaPie` class - GetHttpClient() which fetches new `HttpClient` from `IHttpClientFactory`, which **recommended solution**.

Apart of these optimizations, **improvement suggestion** from @Burgyn within #42 about **asynchronous reporting** was realized.