### PR TITLE
Fix result summary reporter initialization

### DIFF
--- a/docs/docs/how-to-write-tests.md
+++ b/docs/docs/how-to-write-tests.md
@@ -10,6 +10,8 @@ A test is considered **failed** if an exception is thrown within the test body, 
 
 > 💁‍♂️ However, the **natively supported assertion library** is `Xunit.Assert`, which is statically imported in all script files. This means you don't need the `Assert.` prefix to access its methods.
 
+> ⚠️ `.csx` scripts **must not contain code that accesses or processes HTTP responses outside of `tp.Test` methods**. Since the script is executed before all HTTP requests, any response‑dependent logic placed outside `tp.Test` methods **may cause errors**.
+
 ### Example Test
 
 ```csharp

--- a/docs/docs/test-case/post-response-script.md
+++ b/docs/docs/test-case/post-response-script.md
@@ -2,9 +2,10 @@
 
 |   |   |
 |----------------------|----------------|
-| **Definition**       | `.csx` script to be executed after all HTTP requests within test case. |
+| **Definition**       | `.csx` script containing defined test scenarios. |
 | **Naming Convention** | `<test-case-name>-test.csx` |
 | **Purpose**         | Testing given response(s) and tear-down of data. |
+| **Restrictions**    | `.csx` scripts must not contain code that accesses or processes HTTP responses outside of `tp.Test` methods. |
 | **Example Usage**         | [Simple Script](https://github.com/Kros-sk/TeaPie/blob/master/demo/Tests/001-Customers/001-Add-Customer-test.csx), [Manipulation with Body](https://github.com/Kros-sk/TeaPie/blob/master/demo/Tests/002-Cars/001-Add-Car-test.csx), [Another Example](https://github.com/Kros-sk/TeaPie/blob/master/demo/Tests/002-Cars/002-Edit-Car-test.csx), [Advanced Script](https://github.com/Kros-sk/TeaPie/blob/master/demo/Tests/003-Car-Rentals/001-Rent-Car-test.csx) |
 
 ## Features

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>1.5.1</Version>
+        <Version>1.5.2</Version>
         <Authors>Matej Grochal</Authors>
         <Company>KROS a.s.</Company>
         <Copyright>Copyright © KROS a.s.</Copyright>

--- a/src/TeaPie/Reporting/TestResultsSummaryReporter.cs
+++ b/src/TeaPie/Reporting/TestResultsSummaryReporter.cs
@@ -15,6 +15,11 @@ internal class TestResultsSummaryReporter(ITestResultsSummaryAccessor accessor) 
 
     public void Initialize()
     {
+        if (_started)
+        {
+            return;
+        }
+
         _summary = GetSummary();
         _summary.Start();
         _started = true;

--- a/src/TeaPie/TeaPie.csproj
+++ b/src/TeaPie/TeaPie.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <Version>1.3.0</Version>
+    <Version>1.5.2</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/TeaPie/Testing/ExecuteScheduledTestsStep.cs
+++ b/src/TeaPie/Testing/ExecuteScheduledTestsStep.cs
@@ -1,15 +1,22 @@
 ﻿using Microsoft.Extensions.Logging;
 using TeaPie.Pipelines;
+using TeaPie.Reporting;
 
 namespace TeaPie.Testing;
 
-internal class ExecuteScheduledTestsStep(ITestScheduler scheduler, ITester tester) : IPipelineStep
+internal class ExecuteScheduledTestsStep(
+    ITestScheduler scheduler,
+    ITester tester,
+    ITestResultsSummaryReporter resultsSummaryReporter) : IPipelineStep
 {
     private readonly ITestScheduler _scheduler = scheduler;
     private readonly ITester _tester = tester;
+    private readonly ITestResultsSummaryReporter _resultsSummaryReporter = resultsSummaryReporter;
 
     public async Task Execute(ApplicationContext context, CancellationToken cancellationToken = default)
     {
+        _resultsSummaryReporter.Initialize();
+
         while (_scheduler.HasScheduledTest())
         {
             var test = _scheduler.Dequeue();

--- a/src/TeaPie/Testing/Tester.cs
+++ b/src/TeaPie/Testing/Tester.cs
@@ -156,7 +156,7 @@ internal partial class Tester(
     [LoggerMessage(Message = "Skipping test: '{Name}' ({Path})", Level = LogLevel.Information)]
     private static partial void LogTestSkip(ILogger logger, string Name, string Path);
 
-    [LoggerMessage(Message = "Test '{Name}' ({Path}) was already executed during retry evaluation", Level = LogLevel.Information)]
+    [LoggerMessage(Message = "Test '{Name}' ({Path}) was already executed during retry evaluation", Level = LogLevel.Debug)]
     private static partial void LogTestAlreadyExecuted(ILogger logger, string Name, string Path);
 
     #endregion

--- a/tests/TeaPie.Tests/ApplicationPipelineShould.cs
+++ b/tests/TeaPie.Tests/ApplicationPipelineShould.cs
@@ -132,7 +132,7 @@ public class ApplicationPipelineShould
         var registeredTest = CreateTest("registered-test", testCase);
         testCaseContext.RegisterTest(registeredTest);
 
-        var executeScheduledTestsStep = new ExecuteScheduledTestsStep(scheduler, tester);
+        var executeScheduledTestsStep = new ExecuteScheduledTestsStep(scheduler, tester, reporter);
         var runScriptTestsStep = new RunScriptTestsStep(accessor, reporter, tester);
 
         pipeline.AddSteps(executeScheduledTestsStep);

--- a/tests/TeaPie.Tests/Testing/ExecuteScheduledTestsStepShould.cs
+++ b/tests/TeaPie.Tests/Testing/ExecuteScheduledTestsStepShould.cs
@@ -1,0 +1,73 @@
+﻿using NSubstitute;
+using TeaPie.Reporting;
+using TeaPie.StructureExploration;
+using TeaPie.Testing;
+using static Xunit.Assert;
+
+namespace TeaPie.Tests.Testing;
+
+public class ExecuteScheduledTestsStepShould
+{
+    [Fact]
+    public async Task InitializeReporterBeforeExecutingTests()
+    {
+        var scheduler = new TestScheduler();
+        var tester = Substitute.For<ITester>();
+        var reporter = Substitute.For<ITestResultsSummaryReporter>();
+
+        var testCase = new TestCase(new InternalFile("test.http", "test.http", null!));
+        var test = new Test(
+            "test-name",
+            false,
+            async () => await Task.CompletedTask,
+            new TestResult.NotRun() { TestName = "test-name" },
+            testCase);
+
+        scheduler.Schedule(test);
+
+        var step = new ExecuteScheduledTestsStep(scheduler, tester, reporter);
+        var context = new ApplicationContextBuilder()
+            .WithPath(string.Empty)
+            .Build();
+
+        await step.Execute(context);
+
+        reporter.Received(1).Initialize();
+    }
+
+    [Fact]
+    public async Task ExecuteAllScheduledTests()
+    {
+        var scheduler = new TestScheduler();
+        var tester = Substitute.For<ITester>();
+        var reporter = Substitute.For<ITestResultsSummaryReporter>();
+
+        var testCase = new TestCase(new InternalFile("test.http", "test.http", null!));
+        var test1 = CreateTest("test-1", testCase);
+        var test2 = CreateTest("test-2", testCase);
+        var test3 = CreateTest("test-3", testCase);
+
+        scheduler.Schedule(test1);
+        scheduler.Schedule(test2);
+        scheduler.Schedule(test3);
+
+        var step = new ExecuteScheduledTestsStep(scheduler, tester, reporter);
+        var context = new ApplicationContextBuilder()
+            .WithPath(string.Empty)
+            .Build();
+
+        await step.Execute(context);
+
+        await tester.Received(1).ExecuteOrSkipTest(test1, test1.TestCase);
+        await tester.Received(1).ExecuteOrSkipTest(test2, test2.TestCase);
+        await tester.Received(1).ExecuteOrSkipTest(test3, test3.TestCase);
+
+        False(scheduler.HasScheduledTest());
+    }
+
+    private static Test CreateTest(string name, TestCase testCase)
+    {
+        var result = new TestResult.NotRun { TestName = name, TestCasePath = "test.http" };
+        return new Test(name, false, () => Task.CompletedTask, result, testCase);
+    }
+}


### PR DESCRIPTION
Problem: Test scenarios that contained scheduled tests and did not contain a test file had problems with initializing the summary results reporter.
Fix: Add initialization of result summary reporter into execution of scheduling tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate initialization of test results reporter to avoid potential errors.

* **Documentation**
  * Clarified restrictions for test scripts regarding HTTP response handling outside designated methods.
  * Updated testing guidelines for improved script execution clarity.

* **Chores**
  * Version updated to 1.5.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->