### PR TITLE
Add debugging failed tests section to TeaPie skill

### DIFF
--- a/.claude/skills/teapie/SKILL.md
+++ b/.claude/skills/teapie/SKILL.md
@@ -280,6 +280,78 @@ teapie test -v ./Tests/002-Cars/001-Add-Car-req.http
 - Error stack traces
 - Test assertion details
 
+## Debugging Failed Tests
+
+When a test fails or execution errors occur, follow this escalating diagnostic workflow to understand the root cause, explain it clearly to the user, and suggest a fix.
+
+### Step 1: Re-run with Request/Response Logging
+
+Use `--requests-log-file` to capture full HTTP request and response details into a JSONL file:
+
+```bash
+teapie test ./path/to/failing-test -e <environment> --requests-log-file requests.json
+```
+
+Then read the `requests.json` file and examine:
+- **Request**: method, URL, headers, body — verify the request was constructed correctly
+- **Response**: status code, headers, body — check what the server actually returned
+- **Timing**: duration in milliseconds — identify timeouts or slow responses
+- **Errors**: any errors captured during the request
+
+This reveals mismatches between expected and actual HTTP traffic (wrong URL, missing headers, unexpected response body, auth failures, etc.).
+
+Reference: https://www.teapie.fun/docs/requests-logging.html
+
+### Step 2: Re-run with Debug/Verbose Logging
+
+If request/response data alone is insufficient, enable detailed framework logging:
+
+```bash
+# Debug-level logging to console
+teapie test ./path/to/failing-test -e <environment> -d
+
+# Maximum verbosity
+teapie test ./path/to/failing-test -e <environment> -v
+
+# Write debug logs to a file for analysis
+teapie test ./path/to/failing-test -e <environment> --log-file debug.log --log-file-log-level Debug
+```
+
+**CLI logging flags:**
+- `-d` / `--debug` — Activates detailed logging output
+- `-v` / `--verbose` — Most comprehensive logging (includes variable resolution, script execution, full stack traces)
+- `-q` / `--quiet` — Suppresses all output
+- `--log-level <level>` — Sets minimum log level for console
+- `--log-file <path>` — Writes logs to a file
+- `--log-file-log-level <level>` — Sets minimum log level for the log file
+
+Debug/verbose output helps diagnose:
+- Variable resolution failures (unresolved `{{variables}}`)
+- Script compilation or execution errors
+- Authentication provider issues
+- Pipeline step failures
+- Directive processing problems
+
+Reference: https://www.teapie.fun/docs/logging.html
+
+### Step 3: Analyze and Explain
+
+After collecting diagnostic data, you MUST:
+
+1. **Identify the root cause** — Pinpoint exactly what failed and why (e.g., "The server returned 401 because the auth token expired", "Variable `{{baseUrl}}` was not resolved because environment was not set")
+2. **Explain clearly to the user** — Provide a concise, non-technical-jargon explanation of what went wrong, referencing the specific request/response data or log entries
+3. **Suggest a fix** — If possible, propose concrete changes to the test files, scripts, environment config, or CLI invocation that would resolve the issue
+
+### Combined Diagnostic Command
+
+For maximum diagnostic information in a single run:
+
+```bash
+teapie test ./path/to/failing-test -e <environment> --requests-log-file requests.json --log-file debug.log --log-file-log-level Debug -v
+```
+
+This produces both the structured request/response log and detailed framework debug output, giving you everything needed for thorough analysis.
+
 ## Project Analysis
 
 Analyze TeaPie project structure to discover custom extensions, configurations, and shared resources.


### PR DESCRIPTION
## Summary
- Add escalating diagnostic workflow section to the TeaPie Claude skill for handling test failures
- Step 1: Re-run with `--requests-log-file` to capture full HTTP request/response details (JSONL format)
- Step 2: Re-run with debug/verbose logging (`-d`, `-v`, `--log-file`) for framework-level diagnostics
- Step 3: Structured analysis — identify root cause, explain clearly to user, suggest concrete fix
- Includes combined diagnostic command for maximum information in a single run

## Test plan
- [ ] Invoke the `teapie` skill in Claude Code and verify the new "Debugging Failed Tests" section is loaded
- [ ] Verify `--requests-log-file` and logging flags match current TeaPie CLI options
- [ ] Simulate a test failure scenario and confirm the skill guides the agent through the diagnostic workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive debugging guide for failing tests, including escalating diagnostic steps with request/response logging, enhanced framework logging options, and root cause analysis guidance to help troubleshoot test failures effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->